### PR TITLE
Update deploy-develop.sh to prevent css error!

### DIFF
--- a/compose/deploy-develop.sh
+++ b/compose/deploy-develop.sh
@@ -44,5 +44,8 @@ docker run -it --rm -v "/home/ubuntu/.m2":/root/.m2 -v "$(pwd)":/opt/maven -w /o
 
 
 cd $dirlocation/io.openslice.tmf.web
+if [ ! -f  "./src/assets/config/theming.scss" ]; then
+    sudo cp ./src/assets/config/theming.default.scss ./src/assets/config/theming.scss
+fi
 docker run -u 0 --rm -v "$PWD":/app trion/ng-cli npm install
 docker run -u 0 --rm -v "$PWD":/app trion/ng-cli ng build --prod --deleteOutputPath=false


### PR DESCRIPTION
This fixes the following error during the installation process:

```
Generated code for /app/node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[5].rules[0].oneOf[0].use[1]!/app/node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[5].rules[0].oneOf[0].use[2]!/app/node_modules/resolve-url-loader/index.js??ruleSet[1].rules[5].rules[1].use[0]!/app/node_modules/sass-loader/dist/cjs.js??ruleSet[1].rules[5].rules[1].use[1]!/app/src/styles.scss
1 | throw new Error("Module build failed (from ./node_modules/sass-loader/dist/cjs.js):\nSassError: Can't find stylesheet to import.\n   ╷\n11 │ @import \"src/assets/config/theming.scss\";\n   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n   ╵\n  src/styles.scss 11:9  root stylesheet");
```