### PR TITLE
Update docker-compose.yaml.configure to Remove Duplicates & Docker Compose V2 compatibility!

### DIFF
--- a/compose/docker-compose.yaml.configure
+++ b/compose/docker-compose.yaml.configure
@@ -53,7 +53,6 @@ services:
     volumes:
     -  ~/mysql/data:/var/lib/mysql
     - ./mysql-init:/docker-entrypoint-initdb.d
-    restart: always
     networks:
     -  back
 


### PR DESCRIPTION
"restart: always" was duplicated and compose V2 has conflicts with that