### PR TITLE
Update docker-compose.yaml.configure to cope with https://github.com/openslice/io.openslice.portal.api/pull/15 

### DIFF
--- a/compose/docker-compose.yaml.configure
+++ b/compose/docker-compose.yaml.configure
@@ -104,7 +104,9 @@ services:
         "spring.activemq.brokerUrl": "tcp://anartemis:61616?jms.watchTopicAdvisories=false",
         "spring.activemq.user": "artemis",
         "spring.activemq.password": "artemis",
-        "logging.level.org.springframework" : "INFO"        
+        "logging.level.org.springframework" : "INFO",
+        "spring.portal.main.domain": "http://localhost",
+        "spring.portal.portal.title": "Openslice"
       }'
     volumes:
     - ./repo:/root


### PR DESCRIPTION
Should only be accepted if [openslice/io.openslice.portal.api#15](https://github.com/openslice/io.openslice.portal.api/pull/15) is accepted.

This update lists the newly introduced application properties (see [openslice/io.openslice.portal.api#15](https://github.com/openslice/io.openslice.portal.api/pull/15)) in the docker-compose. This way, developers may provide these variables via the docker-compose, which will overwrite the default ones in the application.properties file.  