### PR TITLE
Updated deploy-develop.sh to support Java 17

### DIFF
--- a/compose/deploy-develop.sh
+++ b/compose/deploy-develop.sh
@@ -39,7 +39,7 @@ updaterepo io.openslice.tmf.api
 updaterepo io.openslice.tmf.web
 
 cd $dirlocation
-docker run -it --rm -v "/home/ubuntu/.m2":/root/.m2 -v "$(pwd)":/opt/maven -w /opt/maven/io.openslice.main maven:3.8.2-adoptopenjdk-15-openj9 mvn clean verify -DskipTests
+docker run -it --rm -v "/home/ubuntu/.m2":/root/.m2 -v "$(pwd)":/opt/maven -w /opt/maven/io.openslice.main maven:3.8.3-openjdk-17 mvn clean verify -DskipTests
 
 
 


### PR DESCRIPTION
Previously, the deployment script relied on a `maven:3.8.2-adoptopenjdk-15-openj9` docker image to build and package all services. With the upgrade to Java 17, the deployment script is unable to build the JARs. Thus, this update, which updates the docker image to `maven:3.8.3-openjdk-17`. 